### PR TITLE
Update find_path

### DIFF
--- a/bin/find_path
+++ b/bin/find_path
@@ -1,3 +1,4 @@
+#!/bin/python
 import os
 import argparse
 import logging

--- a/bin/find_path
+++ b/bin/find_path
@@ -1,8 +1,6 @@
-#!/bin/python
+#!/bin/python3
 import os
 import argparse
-import logging
-from pathlib import Path
 from polyply_regression_tests import FF_PATH, DATA_PATH
 import polyply_regression_tests
 


### PR DESCRIPTION
fix missing header in find_path. The missing header causes the exe to be interpreted as bash script at least on MacOS.